### PR TITLE
CBP 50809 - Update image version for assets-plugin-chain-utils

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:37250ef38ed8daf157f4feb9f7a05037128c00a2
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:461fddde1cf288aceac117d98da2ced889892fad
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73
+      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils: 37250ef38ed8daf157f4feb9f7a05037128c00a2
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils

--- a/action.yml
+++ b/action.yml
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://020229604682.dkr.ecr.us-east-1.amazonaws.com/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:8ffcff74b5e47eb284c2b137a00b839db558fde1
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the Docker image references for the `assets-plugin-chain-utils` action in the `action.yml` workflow file. 

Dependency updates:

* Updated the Docker image version for `assets-plugin-chain-utils` from `9c6f7dd273dfaff6d1d03ffaac6cb0261f375e73` to `8ffcff74b5e47eb284c2b137a00b839db558fde1`
