### PR TITLE
feat(CBP-51359): Update Readme Doc Commit

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,6 +56,10 @@ You can also use the action output as a quality gate for the next step or job in
 | String
 | The number of *Low* security findings discovered during the scan.
 
+| `policy-subject`
+| JSON
+| A JSON value containing details about the vulnerability scan summary and details.
+
 |===
 
 
@@ -129,6 +133,7 @@ jobs:
             echo "High count: ${{steps.gitleaks-step.outputs.high-count}}"
             echo "Medium count: ${{steps.gitleaks-step.outputs.medium-count}}"
             echo "Low count: ${{steps.gitleaks-step.outputs.low-count}}"
+            echo "Policy subject: ${{steps.gitleaks-step.outputs.policy-subject}}"
 
 
 ----
@@ -160,6 +165,7 @@ jobs:
       gitleaks-job-output-high: ${{ steps.gitleaks-step.outputs.high-count }}
       gitleaks-job-output-medium: ${{ steps.gitleaks-step.outputs.medium-count }}
       gitleaks-job-output-low: ${{ steps.gitleaks-step.outputs.low-count }}
+      gitleaks-job-output-policy-subject: ${{ steps.gitleaks-step.outputs.policy-subject }}
     steps:
       - name: check out source code
         uses: cloudbees-io/checkout@v1
@@ -186,6 +192,7 @@ jobs:
           echo "High count: ${{ needs.job1.outputs.gitleaks-job-output-high }}"
           echo "Medium count: ${{ needs.job1.outputs.gitleaks-job-output-medium }}"
           echo "Low count: ${{ needs.job1.outputs.gitleaks-job-output-low }}"
+          echo "Policy subject: ${{ needs.job1.outputs.gitleaks-job-output-policy-subject }}"
 
 ----
 

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Clear asset store for container scan
+    - name: Clear asset store for scan
       uses: docker://alpine:latest
       shell: sh
       run: |


### PR DESCRIPTION
This pull request updates the documentation and workflow outputs to include a new `policy-subject` output, which provides a JSON summary of vulnerability scan results. This allows downstream jobs to access detailed scan data for further policy evaluation or reporting.

Key changes:

**Documentation updates:**

* Added documentation for the new `policy-subject` output in the outputs table, describing its format and purpose.
* Updated the example workflow steps to show how to access and print the `policy-subject` output. [[1]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R136) [[2]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R168) [[3]](diffhunk://#diff-1194561cbea346acb1bea37d81fdf5c70def982dcbb0c64eca2a96bc51941124R195)

**Minor improvements:**

* Clarified the step name in `action.yml` from "Clear asset store for container scan" to "Clear asset store for scan" for accuracy.