### PR TITLE
feat(CBP-52533): Update assets-plugin-chain-utils Docker image version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
         fi
 
     - name: Generate sha and ref
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       with:
         entrypoint: assets-plugin-chain-utils
         args: get-commit-info
@@ -60,7 +60,7 @@ runs:
          INPUT_WORKSPACE_DIR: ${{ inputs.workspace-dir }}
 
     - name: Generate reference files
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       with:
           entrypoint: assets-plugin-chain-utils
           args: generate-references --asset-type "CODE"
@@ -79,7 +79,7 @@ runs:
       run: /app/plugin-gitleaks-scanner -mode single
 
     - name: Complete execution plan
-      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d
+      uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-plugin-chain-utils:267bff4ae4e4f12d036c5593ce1864301185c722
       id: process-outputs
       with:
           entrypoint: assets-plugin-chain-utils


### PR DESCRIPTION
This pull request updates the `assets-plugin-chain-utils` Docker image version used in the GitHub Action workflow defined in `action.yml`. The image tag is updated from `d621d66df83be71f6b4b1d1ac7ac9e0de6f6fc7d` to `267bff4ae4e4f12d036c5593ce1864301185c722` in all steps that use this plugin, ensuring consistency and potentially pulling in bug fixes or new features from the updated image.

**Dependency update:**

* Updated the `assets-plugin-chain-utils` Docker image version to `267bff4ae4e4f12d036c5593ce1864301185c722` in all relevant workflow steps in `action.yml`. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L50-R50) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L63-R63) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L82-R82)